### PR TITLE
Added support for pathogen

### DIFF
--- a/README
+++ b/README
@@ -83,6 +83,8 @@ The options expect a string with the path and an integer value like before.
 More completion options:
 The options expect a string as below is explained.
 
+* Set the location of the `erlang_completion.erl' script: (default: "~/.vim/autoload/erlang_completion.erl")
+    g:erlangCompletionFile
 * Set the `grep' command to be use when scanning the man pages: (default: "grep")
 	g:erlangCompletionGrep
 * Set the suffix of the man page names: (default: "")

--- a/autoload/erlangcomplete.vim
+++ b/autoload/erlangcomplete.vim
@@ -11,7 +11,10 @@
 let s:erlangLocalFuncBeg    = '\(\<[0-9A-Za-z_-]*\|\s*\)$'
 let s:erlangExternalFuncBeg = '\<[0-9A-Za-z_-]\+:[0-9A-Za-z_-]*$'
 let s:ErlangBlankLine       = '^\s*\(%.*\)\?$'
-let s:erlangCompletionPath  = '~/.vim/autoload/erlang_completion.erl'
+
+if !exists('g:erlangCompletionFile')
+    let g:erlangCompletionFile  = '~/.vim/autoload/erlang_completion.erl'
+endif
 
 if !exists('g:erlangCompletionGrep')
 	let g:erlangCompletionGrep = 'grep'
@@ -110,7 +113,7 @@ function s:erlangFindExternalFunc(module, base)
             silent execute '!erlc' a:module . '.erl' '>/dev/null' '2>/dev/null'
             redraw!
         endif
-        let functions = system(s:erlangCompletionPath . ' ' . a:module)
+        let functions = system(g:erlangCompletionFile . ' ' . a:module)
         for element in sort(split(functions, '\n'))
             if match(element, a:base) == 0
                 let function_name = matchstr(element, a:base . '\w\+')


### PR DESCRIPTION
Hi,

I use [pathogen](https://github.com/tpope/vim-pathogen/) to manage my vim plugins. Pathogen keeps the plugins inside <code>~/.vim/bundle</code>, this breaks vimerl's omni-completion. This patch lets you configure the location of the <code>erlang_completion.erl</code> script in your _vimrc_ file.

Vimerl's omni-completion and compiler under pathogen:
https://github.com/tapichu/vimdir/blob/master/.vimrc#L43-44

Cheers
