### PR TITLE
Automatically insert the current comment leader

### DIFF
--- a/ftplugin/erlang.vim
+++ b/ftplugin/erlang.vim
@@ -50,6 +50,9 @@ function s:SetErlangOptions()
 	setlocal foldexpr=GetErlangFold(v:lnum)
 	setlocal foldtext=ErlangFoldText()
 	let &l:keywordprg=g:erlangKCommand
+	setlocal comments-=:%
+	setlocal comments+=:%%%,:%%,:%
+	setlocal formatoptions+=ro
 endfunction
 
 " Define folding functions


### PR DESCRIPTION
Hi,

I was getting bored of writing so many percent signs for module and function comments / docs. Vim can automatically insert them for me.

More details in the commit message:
https://github.com/tapichu/vimerl/commit/e5d3da853f3e2ed837649c6afe0301eb89b28ef0

Un saludo.
