### PR TITLE
BIF highlighting should be optional

### DIFF
--- a/syntax/erlang.vim
+++ b/syntax/erlang.vim
@@ -105,7 +105,6 @@ hi link erlangFloat          Number
 hi link erlangFloat          Number
 hi link erlangFloat          Number
 hi link erlangHex            Number
-hi link erlangBIF            Keyword
 hi link erlangFun            Keyword
 hi link erlangList           Delimiter
 hi link erlangTuple          Delimiter
@@ -117,6 +116,7 @@ hi link erlangBitSize        Number
 
 " Optional linking
 if exists("g:erlangHighlightBIFs") && g:erlangHighlightBIFs
+	hi link erlangBIF    Keyword
 	hi link erlangGBIF   Keyword
 endif
 


### PR DESCRIPTION
The README says:
- Highlight all Erlang BIFs (functions from `erlang' module) as keywords: (default: 0)
  g:erlangHighlightBIFs

But without this change BIF highlighting is always enabled.

Maybe we should enable BIF highlighting by default, but still make it optional.
