### PR TITLE
Disable syntax checker when using Syntastic plugin

### DIFF
--- a/compiler/erlang.vim
+++ b/compiler/erlang.vim
@@ -4,7 +4,7 @@
 " Contributors: Ricardo Catalinas Jiménez <jimenezrick@gmail.com>
 " Version:      2011/12/14
 
-if exists("current_compiler")
+if exists("current_compiler") || exists(":SyntasticCheck")
     finish
 else
     let current_compiler = "erlang"


### PR DESCRIPTION
Syntastic plugin adds the same functionality, but there are more languages supported. Compiling *.erl two times makes vim slower.
