### PR TITLE
Fix problem with completion on OSX

### DIFF
--- a/autoload/erlang_complete.vim
+++ b/autoload/erlang_complete.vim
@@ -19,7 +19,11 @@ endif
 let s:erlang_complete_file = expand('<sfile>:p:h') . '/erlang_complete.erl'
 
 " Man pages path
-let s:erlang_man_path = system("grep ^ROOTDIR= $(which erl) | sed 's/^.*=//'")[:-2] . '/man'
+if substitute(system('uname'), "\n", "", "") == "Darwin"
+    let s:erlang_man_path = system("grep ^ROOTDIR= $(which erl) | sed 's/^.*=//' | sed 's/\\/lib\\/erlang$//'")[:-2] . '/share/man'
+else
+    let s:erlang_man_path = system("grep ^ROOTDIR= $(which erl) | sed 's/^.*=//'")[:-2] . '/man'
+endif
 
 " Modules cache used to speed up the completion
 let s:modules_cache = {}


### PR DESCRIPTION
Ricardo,

The man path on OSX (at least when erlang is installed with brew) is `/usr/local/Cellar/erlang/R14B04/share/man` but the root dir is `/usr/local/Cellar/erlang/R14B04/lib/erlang` so the completion was not working correctly.

This is a quick fix, but I'll try coming up with a more general solution. Maybe going up to the `R\d+B\d+` dir and searching for a `man` dir, or something like that.
