### PR TITLE
Fix to search deeper to find include files

### DIFF
--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -10,7 +10,11 @@ main([File]) ->
             warn_unused_import,
             report,
             {i, Dir ++ "/include"},
-            {i, Dir ++ "/../include"}],
+            {i, Dir ++ "/../include"},
+            {i, Dir ++ "/../../include"},
+            {i, Dir ++ "/../../../include"},
+            {i, Dir ++ "/../../../../include"},
+            {i, Dir ++ "/../../../../../include"}],
     case file:consult("rebar.config") of
         {ok, Terms} ->
             RebarDeps = proplists:get_value(deps_dir, Terms, "deps"),


### PR DESCRIPTION
It's quite common for my directory structure to have several depths of files in src:

ie /src/lib/db/db_whatever.erl

This fix will alllow the compilation escript to drop back enough levels to find the include files, with a few extra for good measure.  Ideally, it could drop back recursively until it encounters an include dir, but this is a quick and dirty fix for the immediate moment.

What do you think?
