### PR TITLE
Add lib_dirs to omni completed paths

### DIFF
--- a/autoload/erlang_complete.erl
+++ b/autoload/erlang_complete.erl
@@ -7,7 +7,14 @@ main([ModName]) ->
     case file:consult("rebar.config") of
         {ok, Terms} ->
             RebarDeps = proplists:get_value(deps_dir, Terms, "deps"),
-            code:add_paths(filelib:wildcard(RebarDeps ++ "/*/ebin"));
+            code:add_paths(filelib:wildcard(RebarDeps ++ "/*/ebin")),
+            RebarLibDirs = proplists:get_value(lib_dirs, Terms, []),
+            lists:foreach(
+                fun (LibDir) ->
+                    code:add_pathsz(filelib:wildcard(LibDir ++ "/*/ebin"))
+                end,
+                RebarLibDirs
+            );
         _ ->
             ok
     end,


### PR DESCRIPTION
Hi,

I propose, in addition to `deps`, to add `lib_dirs` to code paths for searching for modules for completion. I followed your method of looking at `/*/ebin/` but in general I am not sure if this is the right thing to do, because some people might have non-orthodox setups and `*.erl` files in other directories, but in order to solve this issue you'd have to use/duplicate a lot of rebar code. I'm not sure how to solve this elegantly really.

Let me know what do you think about this.

Ignas 
