### PR TITLE
Tiny compiler fix

### DIFF
--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -27,6 +27,7 @@ main([File]) ->
             RebarOpts = []
     end,
     code:add_patha("ebin"),
+    code:add_path(filename:absname("ebin")),
     compile:file(File, Defs ++ RebarOpts);
 main(_) ->
     io:format("Usage: ~s <file>~n", [escript:script_name()]),


### PR DESCRIPTION
This patch fixes a situation, when the compiler wants to include a library file from the library code.
For example, this directive is working now for xapian application:
-include_lib("xapian/include/xapian.hrl").
With the old variant error "can't find include lib" was occurred.
