### PR TITLE
Add support for rebar test configs

### DIFF
--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -13,7 +13,25 @@ main([File]) ->
             {i, Dir ++ "/../include"},
             {i, Dir ++ "/../../include"},
             {i, Dir ++ "/../../../include"}],
-    case file:consult("rebar.config") of
+    RebarFile = rebar_file(Dir),
+    RebarOpts = rebar_opts(RebarFile),
+    code:add_patha(filename:absname("ebin")),
+    compile:file(File, Defs ++ RebarOpts);
+main(_) ->
+    io:format("Usage: ~s <file>~n", [escript:script_name()]),
+    halt(1).
+
+rebar_file(Dir) ->
+    DirList = filename:split(Dir),
+    case lists:last(DirList) of
+        "test" ->
+            "rebar.test.config";
+        _ ->
+            "rebar.config"
+    end.
+
+rebar_opts(RebarFile) ->
+   case file:consult(RebarFile) of
         {ok, Terms} ->
             RebarLibDirs = proplists:get_value(lib_dirs, Terms, []),
             lists:foreach(
@@ -22,12 +40,10 @@ main([File]) ->
                 end, RebarLibDirs),
             RebarDepsDir = proplists:get_value(deps_dir, Terms, "deps"),
             code:add_pathsa(filelib:wildcard(RebarDepsDir ++ "/*/ebin")),
-            RebarOpts = proplists:get_value(erl_opts, Terms, []);
+            proplists:get_value(erl_opts, Terms, []);
+        {error, _} when RebarFile == "rebar.config" ->
+            [];
         {error, _} ->
-            RebarOpts = []
-    end,
-    code:add_patha(filename:absname("ebin")),
-    compile:file(File, Defs ++ RebarOpts);
-main(_) ->
-    io:format("Usage: ~s <file>~n", [escript:script_name()]),
-    halt(1).
+            rebar_opts("rebar.config")
+    end.
+


### PR DESCRIPTION
Allow an alternative rebar config for tests.

The pull request will default to rebar.test.config (instead of rebar.config) for .erl files in a "test" sub-directory. If there is an error in rebar.test.config or it does not exist, then will try rebar.config (fall back to previous behaviour).

I'm not aware of a standard so perhaps rebar.test.config is the incorrect choice.
