### PR TITLE
Add indent support for stand alone data structures

### DIFF
--- a/indent/erlang_indent.erl
+++ b/indent/erlang_indent.erl
@@ -158,8 +158,15 @@ parse_tokens(Tokens = [{'-', _} | _]) ->
     parse_attribute(Tokens, #state{});
 parse_tokens(Tokens = [{atom, _, _} | _]) ->
     parse_function(Tokens, #state{});
+parse_tokens(Tokens = [{T, _} | _]) when T == '['; T == '{'; T == '('; T = '<<' ->
+    parse_datum(Tokens, #state{});
 parse_tokens(Tokens) ->
     throw({parse_error, Tokens, #state{}, ?LINE}).
+
+parse_datum([T | Tokens], State) ->
+    parse_next(Tokens, indent(push(State, T, 0), 1));
+parse_datum([], State) ->
+    State.
 
 parse_attribute([T = {'-', _}, {atom, _, export} | Tokens], State = #state{stack = []}) ->
     parse_next(Tokens, push(State, T, -1));


### PR DESCRIPTION
The current indenter expects that there are functions and definitions which
works well on source files i.e. code.  When attempting to indent config files
(e.g. app.config) then indenter would align everything to column 0.

This patch makes indenting of config files work as well.
