### PR TITLE
Fix stalling due to invalid guard expression

### DIFF
--- a/indent/erlang_indent.erl
+++ b/indent/erlang_indent.erl
@@ -158,7 +158,7 @@ parse_tokens(Tokens = [{'-', _} | _]) ->
     parse_attribute(Tokens, #state{});
 parse_tokens(Tokens = [{atom, _, _} | _]) ->
     parse_function(Tokens, #state{});
-parse_tokens(Tokens = [{T, _} | _]) when T == '['; T == '{'; T == '('; T = '<<' ->
+parse_tokens(Tokens = [{T, _} | _]) when T == '['; T == '{'; T == '(' ->
     parse_datum(Tokens, #state{});
 parse_tokens(Tokens) ->
     throw({parse_error, Tokens, #state{}, ?LINE}).


### PR DESCRIPTION
It appears that I introduced a bad guard expression in the prior pull request.  Specifically:

T = '<<' ->

which was one of the last additions I made to the script.  Somehow I failed to test/notice it for 24 hours.  This patch fixes it...
