### PR TITLE
Add support for nested dirs inside src/

### DIFF
--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -10,6 +10,9 @@ main([File]) ->
             warn_unused_import,
             report,
             {i, Dir ++ "/include"},
+            {i, Dir ++ "/../include"},
+            {i, Dir ++ "/../../include"},
+            {i, Dir ++ "/../../../include"},
             {i, Dir ++ "/lib"},
             {i, Dir ++ "/deps"}],
     RebarFile = rebar_file(Dir),
@@ -32,7 +35,7 @@ rebar_file(Dir) ->
 
 get_root(Dir) ->
     Path = filename:split(filename:absname(Dir)),
-    filename:join(get_root(lists:reverse(Path), [])).
+    filename:join(get_root(lists:reverse(Path), Path)).
 
 get_root([], Path) ->
     Path;


### PR DESCRIPTION
When having nested directories (for instance `src/protocol/tm_proto.erl`)
autocompilation would fail. This fix adds the abspath of all depdencies to
the codepath and sets compile option {i, _} to support both `lib/ and`deps/`.
