### PR TITLE
Folding option for comment blocks

### DIFF
--- a/doc/vimerl.txt
+++ b/doc/vimerl.txt
@@ -74,7 +74,7 @@ Note: indenting a large block of lines with the |=| or |v_=| command will take
 2.2 Code folding                                              *vimerl-folding*
 
 In order to enable/disable code folding see the |'foldenable'| Vim option and
-also enable the |'erlang_folding'| option.
+also enable the |'erlang_folding'| and |'erlang_folding_comments'| option.
 
 ------------------------------------------------------------------------------
 2.3 Code omni completion                              *vimerl-omni-completion*
@@ -186,6 +186,14 @@ The following options offer the possibility to customize the plugin behaviour.
 This option controls whether automatic code folding is enabled or disabled
 (default: 0, values: 0 or 1): >
 	:let erlang_folding = 0
+
+------------------------------------------------------------------------------
+                                                   *'erlang_folding_comments'*
+
+This option controls whether automatic comment block (multiple lines,
+starting with '%%') folding is enabled or disabled
+(default: 0, values: 0 or 1): >
+	:let erlang_folding_comments = 0
 
 ------------------------------------------------------------------------------
                                                       *'erlang_highlight_bif'*

--- a/ftplugin/erlang.vim
+++ b/ftplugin/erlang.vim
@@ -3,8 +3,9 @@
 " Author:       Oscar Hellström <oscar@oscarh.net>
 " Contributors: Ricardo Catalinas Jiménez <jimenezrick@gmail.com>
 "               Eduardo Lopez (http://github.com/tapichu)
+"               Markus Mroch <mmroch@mr-pi.de> (https://mr-pi.de)
 " License:      Vim license
-" Version:      2012/11/25
+" Version:      2013-11-15
 
 if exists('b:did_ftplugin')
 	finish
@@ -29,6 +30,9 @@ endif
 
 let s:erlang_fun_begin = '^\(\a\w*\|[''][^'']*['']\)(.*$'
 let s:erlang_fun_end   = '^[^%]*\.\s*\(%.*\)\?$'
+
+let s:erlang_commentBlock_begin = '^%*\( @private\| @doc\| @doc .*\)$'
+let s:erlang_commentBlock_end   = '^%*\( @end\)$'
 
 function s:SetErlangOptions()
 	compiler erlang
@@ -55,6 +59,7 @@ function GetErlangFold(lnum)
 	let lnum = a:lnum
 	let line = getline(lnum)
 
+	"function folding
 	if line =~ s:erlang_fun_end
 		return '<1'
 	endif
@@ -64,6 +69,19 @@ function GetErlangFold(lnum)
 	endif
 
 	if line =~ s:erlang_fun_begin
+		return '>1'
+	endif
+
+	"comment block folding
+	if line =~ s:erlang_commentBlock_end
+		return '<1'
+	endif
+
+	if line =~ s:erlang_commentBlock_begin && foldlevel(lnum - 1) == 1
+		return '1'
+	endif
+
+	if line =~ s:erlang_commentBlock_begin
 		return '>1'
 	endif
 


### PR DESCRIPTION
Folding can be enabled for comment blocks(starting with '%%'), this is possible, by set the option erlang_folding_comments to 1.

Example:

``` erlang
%%--------------------------------------------------
%% @private
%% @doc some comment
%% stuff
%%--------------------------------------------------
```

will be collapse to:

```
-DOC: some comment
```
