### PR TITLE
Remove `query' from the list of keywords

### DIFF
--- a/syntax/erlang.vim
+++ b/syntax/erlang.vim
@@ -32,7 +32,7 @@ syn match   erlangAnnotation                 /\%(%\s\)\@<=@\%(author\|clear\|cop
 syn match   erlangAnnotation                 /`[^']\+'/ contained
 
 syn keyword erlangKeyword                    band bor bnot bsl bsr bxor div rem xor
-syn keyword erlangKeyword                    try catch begin receive after cond fun let query
+syn keyword erlangKeyword                    try catch begin receive after cond fun let
 
 syn keyword erlangConditional                case if of end
 syn keyword erlangConditional                not and or andalso orelse


### PR DESCRIPTION
Since R16 `query` ist not a reserved word anymore.

This PR removes `query` as a keyword.
