### PR TITLE
Added highlighting for functions

### DIFF
--- a/syntax/erlang.vim
+++ b/syntax/erlang.vim
@@ -79,6 +79,9 @@ syn match erlangBIF                          /\%([^:0-9A-Za-z_]\|\<erlang:\|^\)\
 syn match erlangBIF                          /\%(\<erlang:\)\@<=\%(append_element\|bump_reductions\|cancel_timer\|decode_packet\|display\|function_exported\|fun_info\|fun_to_list\|get_cookie\|get_stacktrace\|hash\|is_builtin\|loaded\|load_nif\|localtime\|localtime_to_universaltime\|make_tuple\|memory\|monitor_node\|phash\|port_call\|port_info\|ports\|port_to_list\|process_display\|read_timer\|ref_to_list\|resume_process\|send\|send_after\|send_nosuspend\|set_cookie\|start_timer\|suspend_process\|system_flag\|system_info\|system_monitor\|system_profile\|trace\|trace_delivered\|trace_info\|trace_pattern\|universaltime\|universaltime_to_localtime\|yield\)(\@=/
 syn match erlangGBIF                         /\<erlang\%(:\w\)\@=/
 
+" Functions
+syn match erlangFunc                        "^\w\+\s*("
+
 " Link Erlang stuff to Vim groups
 hi def link erlangTodo           Todo
 hi def link erlangString         String
@@ -118,6 +121,7 @@ hi def link erlangBitVariable    Identifier
 hi def link erlangBitType        Type
 hi def link erlangType           Type
 hi def link erlangBitSize        Number
+hi def link erlangFunc           Function
 
 " Optional highlighting
 if g:erlang_highlight_bif


### PR DESCRIPTION
Without patch:
![vimerl func without patch](https://cloud.githubusercontent.com/assets/234891/2969856/aabbeef6-db52-11e3-85d8-6e332f933c3b.png)

With patch:
![vimerl func with patch](https://cloud.githubusercontent.com/assets/234891/2969858/b78b2fac-db52-11e3-8f44-286c9e2ba223.png)

Vim 7.4 & Ubuntu 13.10 with theme https://github.com/morhetz/gruvbox (dark)
