### PR TITLE
Fix simplify_return function when passed the 'abstype'

### DIFF
--- a/autoload/erlang_complete.erl
+++ b/autoload/erlang_complete.erl
@@ -113,10 +113,11 @@ simplify_return({typevar, [{name, Name}], _}) ->
     Name;
 simplify_return({type, _, [Type]}) ->
     simplify_return(Type);
-simplify_return({abstype, _, [Type]}) ->
+simplify_return({abstype, _, [Type | AbsTypes]}) ->
     {erlangName, Attrs, _} = Type,
     Name = proplists:get_value(name, Attrs),
-    Name ++ "()";
+    Elems = lists:map(fun(T) -> simplify_return(T) end, AbsTypes),
+    Name ++ "(" ++ string:join(Elems, ", ") ++ ")";
 simplify_return({record, _, [Type]}) ->
     simplify_return(Type) ++ "()";
 simplify_return({nonempty_list, _, [Type]}) ->


### PR DESCRIPTION
I have encountered an error.

$ ./erlang_complete.erl array
escript: exception error: {function_clause,
                     [{local,simplify_return,
                          [{abstype,
                               [{href,"#type-array"}],
                               [{erlangName,[{name,"array"}],[]},
                                {type,
                                    [{name,"Type"}],
                                    [{typevar,[{name,"Type"}],[]}]}]}]}]}
