### PR TITLE
Fix E885 error on vim 7.4.275 and later

### DIFF
--- a/compiler/erlang.vim
+++ b/compiler/erlang.vim
@@ -49,6 +49,9 @@ function s:ShowErrors()
 	endif
 	silent make!
 	for error in getqflist()
+		if error.lnum == 0
+			continue
+		endif
 		let item         = {}
 		let item["lnum"] = error.lnum
 		let item["text"] = error.text


### PR DESCRIPTION
vim 7.4.275 and later does not allow error sign on line 0.
Here's related linkes:
- https://github.com/scrooloose/syntastic/issues/1093
- http://ftp.vim.org/vim/patches/7.4/7.4.275
